### PR TITLE
Fix how body is retrieved from ResponseInterface

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,11 +7,11 @@
 /composer.lock       export-ignore
 
 # Do not put this files on a distribution package
-/docs/               export-ignore
 /tests/              export-ignore
 /.gitattributes      export-ignore
 /.gitignore          export-ignore
 /.php_cs.dist        export-ignore
+/.phplint.yml        export-ignore
 /.scrutinizer.yml    export-ignore
 /.travis.yml         export-ignore
 /phpcs.xml.dist      export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /vendor
 /build
 /composer.lock
-.phpunit.result.cache

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,11 +6,6 @@ filter:
 build:
   nodes:
     analysis:
-      environment:
-        php:
-          version: "7.3"
-      project_setup:
-        override: true
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,19 @@ sudo: false
 php:
   - "7.2"
   - "7.3"
+  - "7.4snapshot"
+
+matrix:
+  allow_failures:
+    - php: "7.4snapshot"
 
 cache:
   - directories:
     - $HOME/.composer
 
 before_script:
+  - phpenv config-rm xdebug.ini || true
   - travis_retry composer install --no-interaction --prefer-dist
-  - phpenv config-rm xdebug.ini
   - mkdir -p build
 
 script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ By participating in this project and its community, you are expected to uphold t
 ## Team members
 
 * [Carlos C Soto](https://github.com/eclipxe13) - original author and maintainer
-* [GitHub constributors](https://github.com/phpcfdi/sat-estado-cfdi-http-psr/graphs/contributors)
+* [GitHub contributors](https://github.com/phpcfdi/sat-estado-cfdi-http-psr/graphs/contributors)
 
 ## Communication Channels
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Carlos C Soto
+Copyright (c) 2019 PHPCFDI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [coverage]: https://scrutinizer-ci.com/g/phpcfdi/sat-estado-cfdi-http-psr/code-structure/master/code-coverage
 [downloads]: https://packagist.org/packages/phpcfdi/sat-estado-cfdi-http-psr
 
-[badge-source]: http://img.shields.io/badge/source-phpcfdi/sat--estado--cfdi--http--psr-blue.svg?style=flat-square
-[badge-release]: https://img.shields.io/github/release/phpcfdi/sat-estado-cfdi-http-psr.svg?style=flat-square
-[badge-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
-[badge-build]: https://img.shields.io/travis/phpcfdi/sat-estado-cfdi-http-psr/master.svg?style=flat-square
-[badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/sat-estado-cfdi-http-psr/master.svg?style=flat-square
-[badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/sat-estado-cfdi-http-psr/master.svg?style=flat-square
-[badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/sat-estado-cfdi-http-psr.svg?style=flat-square
+[badge-source]: http://img.shields.io/badge/source-phpcfdi/sat--estado--cfdi--http--psr-blue?style=flat-square
+[badge-release]: https://img.shields.io/github/release/phpcfdi/sat-estado-cfdi-http-psr?style=flat-square
+[badge-license]: https://img.shields.io/github/license/phpcfdi/sat-estado-cfdi-http-psr?style=flat-square
+[badge-build]: https://img.shields.io/travis/phpcfdi/sat-estado-cfdi-http-psr/master?style=flat-square
+[badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/sat-estado-cfdi-http-psr/master?style=flat-square
+[badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/sat-estado-cfdi-http-psr/master?style=flat-square
+[badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/sat-estado-cfdi-http-psr?style=flat-square

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ y recuerda revisar el archivo de tareas pendientes [TODO][] y el [CHANGELOG][].
 
 ## Copyright and License
 
-The phpcfdi/sat-estado-cfdi library is copyright © [Carlos C Soto](http://eclipxe.com.mx/)
+The `phpcfdi/sat-estado-cfdi-http-psr` library is copyright © [Carlos C Soto](http://eclipxe.com.mx/)
 and licensed for use under the MIT License (MIT). Please see [LICENSE][] for more information.
 
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ y recuerda revisar el archivo de tareas pendientes [TODO][] y el [CHANGELOG][].
 
 ## Copyright and License
 
-The `phpcfdi/sat-estado-cfdi-http-psr` library is copyright © [Carlos C Soto](http://eclipxe.com.mx/)
+The `phpcfdi/sat-estado-cfdi-http-psr` library is copyright © [PhpCfdi](https://www.phpcfdi.com/)
 and licensed for use under the MIT License (MIT). Please see [LICENSE][] for more information.
 
 

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         ],
         "dev:test": [
             "vendor/bin/phplint",
+            "@dev:check-style",
             "vendor/bin/phpunit --testdox --verbose --stop-on-failure",
             "find . -type f -name .phpunit.result.cache -delete",
             "vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/"
@@ -79,7 +80,7 @@
         "dev:build": "DEV: run dev:fix-style dev:tests and dev:docs, run before pull request",
         "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
         "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
-        "dev:test": "DEV: run phplint, phpunit and phpstan",
+        "dev:test": "DEV: run phplint, @dev:check-style, phpunit and phpstan",
         "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "ext-curl": "*",
         "phpcfdi/cfdi-expresiones": "^2.0",
-        "sunrise/http-client-curl": "^1.0.3",
+        "sunrise/http-client-curl": "^1.1.0",
         "sunrise/http-factory": "^1.0",
         "sunrise/http-message": "^1.0",
         "phpunit/phpunit": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
     "authors": [
         {
             "name": "Carlos C Soto",
-            "email": "eclipxe13@gmail.com",
-            "homepage": "http://eclipxe.com.mx/"
+            "email": "eclipxe13@gmail.com"
         }
     ],
     "support": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## Version 0.2.2 2019-09-23
+
+- Fix usage of `RequestInterface`, to retrieve full body is recommended to use `StreamInterface::__toString()`.
+- Fix testing based on [`sunrise-php/http-client-curl`](https://github.com/sunrise-php/http-client-curl) because
+  they changed their API from `1.0` to `1.1` and it broke object construction. Too late to report a SemVer issue.
+- Improve `composer.json#support` section (PR #4)
+- Package include `docs/` and exclude development file `.phplint.yml`
+- Development:
+    - Improve `composer dev:build` to include `dev:check-style`.
+    - Write `.phpunit.result.cache` on `build/`.
+    - On Travis CI add PHP version `7.4snapshot` with allow failure
+    - Let Scrutinizer CI decide which PHP version to use
+
+
 ## Version 0.2.1 2019-05-16
 
 - Change dependence versions `phpcfdi/sat-estado-cfdi: ^0.6.1|^0.7.0`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,6 +1,5 @@
 # phpcfdi/sat-estado-cfdi-http-psr To Do List
 
-- Poner el copyright correcto en cuanto esté el sitio de PhpCfdi
 - Documentar cómo se puede integrar esta librería con una aplicación de framework o librería común
     - [ ] Laravel
     - [ ] Symfony

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,4 +1,4 @@
-# phpcfdi/sat-estado-cfdi To Do List
+# phpcfdi/sat-estado-cfdi-http-psr To Do List
 
 - Poner el copyright correcto en cuanto esté el sitio de PhpCfdi
 - Documentar cómo se puede integrar esta librería con una aplicación de framework o librería común

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd"
-         bootstrap="./tests/bootstrap.php" colors="true" verbose="true" cacheTokens="false">
+         bootstrap="./tests/bootstrap.php" colors="true" cacheResultFile="build/.phpunit.result.cache">
     <testsuites>
         <testsuite name="Default">
             <directory>./tests/</directory>

--- a/src/HttpConsumerClient.php
+++ b/src/HttpConsumerClient.php
@@ -65,7 +65,7 @@ class HttpConsumerClient implements ConsumerClientInterface
         // parameters --convert--> request --httpCall--> response --convert--> ConsumerClientResponse
         $request = $this->createHttpRequest($uri, $expression);
         $response = $this->sendRequest($request);
-        return $this->createConsumerClientResponse($response->getBody()->getContents());
+        return $this->createConsumerClientResponse($response->getBody()->__toString());
     }
 
     /**

--- a/tests/SunriseHttpConsumerFactory.php
+++ b/tests/SunriseHttpConsumerFactory.php
@@ -23,7 +23,7 @@ class SunriseHttpConsumerFactory extends HttpConsumerFactory implements HttpCons
     ) {
         $streamFactoryInterface = $streamFactoryInterface ?? new SunriseStreamFactory();
         $requestFactoryInterface = $requestFactoryInterface ?? new SunriseRequestFactory();
-        $httpClient = $httpClient ?? new SunriseHttpClient(new SunriseResponseFactory(), $streamFactoryInterface);
+        $httpClient = $httpClient ?? new SunriseHttpClient(new SunriseResponseFactory());
         parent::__construct($httpClient, $requestFactoryInterface, $streamFactoryInterface);
     }
 }


### PR DESCRIPTION
- Fix usage of `RequestInterface`, to retrieve full body is recommended to use `StreamInterface::__toString()`.
- Fix testing based on [`sunrise-php/http-client-curl`](https://github.com/sunrise-php/http-client-curl) because
  they changed their API from `1.0` to `1.1` and it broke object construction. Too late to report a SemVer issue.
- Improve `composer.json#support` section (PR #4)
- Package include `docs/` and exclude development file `.phplint.yml`
- Development:
    - Improve `composer dev:build` to include `dev:check-style`.
    - Write `.phpunit.result.cache` on `build/`.
    - On Travis CI add PHP version `7.4snapshot` with allow failure
    - Let Scrutinizer CI decide which PHP version to use
- Set ownership to PHPCFDI