### PR TITLE
Version 1.0.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,16 +2,20 @@
 * text=auto
 
 # Do not put this files on a distribution package (by .gitignore)
-/vendor/             export-ignore
-/composer.lock       export-ignore
+/tools/                     export-ignore
+/vendor/                    export-ignore
+/composer.lock              export-ignore
 
 # Do not put this files on a distribution package
-/build/              export-ignore
-/tests/              export-ignore
-/.gitattributes      export-ignore
-/.gitignore          export-ignore
-/.php_cs.dist        export-ignore
-/.scrutinizer.yml    export-ignore
-/.travis.yml         export-ignore
-/phpcs.xml.dist      export-ignore
-/phpunit.xml.dist    export-ignore
+/.github/                   export-ignore
+/build/                     export-ignore
+/tests/                     export-ignore
+/.gitattributes             export-ignore
+/.gitignore                 export-ignore
+/.php-cs-fixer.dist.php     export-ignore
+/.scrutinizer.yml           export-ignore
+/infection.json.dist        export-ignore
+/phpcs.xml.dist             export-ignore
+/phpstan.neon.dist          export-ignore
+/phpunit.xml.dist           export-ignore
+/psalm.xml.dist             export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # do not include this files on git
-/vendor
+/tools/
+/vendor/
 /composer.lock

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=7.3",
         "ext-dom": "*",
-        "phpcfdi/sat-estado-cfdi": "^1.0.0",
+        "phpcfdi/sat-estado-cfdi": "^1.0.2",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,8 +6,8 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios no liberados en una versión
 
-Pueden aparecer cambios no liberados que se integran a la rama principal pero no ameritan una nueva liberación de
-versión aunque sí su incorporación en la rama principal de trabajo, generalmente se tratan de cambios en el desarrollo.
+Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
+versión, aunque sí su incorporación en la rama principal de trabajo. Generalmente se tratan de cambios en el desarrollo.
 
 ## Listado de cambios
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,13 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
+### Version 1.0.2 2021-11-04
+
+- Se actualiza la dependencia `phpcfdi/sat-estado-cfdi:^1.0.2`.
+- Se eliminan los archivos `tools/*` que estaban en el repositorio.
+- Se corrigen los archivos ignorados para que incluya el directorio `tools`. 
+- Se corrigen los archivos excluidos del paquete de distribución.
+
 ### Version 1.0.1 2021-09-03
 
 - La versión menor de PHP es 7.3.

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -3,9 +3,6 @@
     "source": {
         "directories": [
             "src"
-        ],
-        "excludes": [
-            "ComplianceTester/ComplianceTester.php"
         ]
     },
     "logs": {

--- a/tools/infection
+++ b/tools/infection
@@ -1,1 +1,0 @@
-/home/eclipxe/.phive/phars/infection-0.23.0.phar

--- a/tools/php-cs-fixer
+++ b/tools/php-cs-fixer
@@ -1,1 +1,0 @@
-/home/eclipxe/.phive/phars/php-cs-fixer-3.1.0.phar

--- a/tools/phpcbf
+++ b/tools/phpcbf
@@ -1,1 +1,0 @@
-/home/eclipxe/.phive/phars/phpcbf-3.6.0.phar

--- a/tools/phpcs
+++ b/tools/phpcs
@@ -1,1 +1,0 @@
-/home/eclipxe/.phive/phars/phpcs-3.6.0.phar

--- a/tools/phpstan
+++ b/tools/phpstan
@@ -1,1 +1,0 @@
-/home/eclipxe/.phive/phars/phpstan-0.12.98.phar

--- a/tools/psalm
+++ b/tools/psalm
@@ -1,1 +1,0 @@
-/home/eclipxe/.phive/phars/psalm-4.9.3.phar


### PR DESCRIPTION
- Se actualiza la dependencia `phpcfdi/sat-estado-cfdi:^1.0.2`.
- Se eliminan los archivos `tools/*` que estaban en el repositorio.
- Se corrigen los archivos ignorados para que incluya el directorio `tools`.
- Se corrigen los archivos excluidos del paquete de distribución.