### PR TITLE
Fix build 2022-03-08

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           fail-fast: true
       - name: Code style (phpcs)
-        run: phpcs -q --report=checkstyle src/ tests/ | cs2pr
+        run: phpcs -q --report=checkstyle | cs2pr
 
   php-cs-fixer:
     name: Code style (php-cs-fixer)

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.6.0" installed="3.6.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.6.0" installed="3.7.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.4.6" installed="1.4.6" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^4.21.0" installed="4.21.0" location="./tools/psalm" copy="false"/>
+  <phar name="phpstan" version="^1.4.6" installed="1.4.8" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^4.21.0" installed="4.22.0" location="./tools/psalm" copy="false"/>
   <phar name="infection" version="^0.23.0" installed="0.23.0" location="./tools/infection" copy="false"/>
 </phive>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,14 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
 versión, aunque sí su incorporación en la rama principal de trabajo. Generalmente se tratan de cambios en el desarrollo.
 
+### Fix build 2022-03-08
+
+Se corrige la integración continua porque PHPStan 1.4.8 no reconoce el tipo de elementos contenidos
+en un objeto de tipo `DOMNodeList`.
+
+En la integración continua la herramienta `phpcs` tenía fijos los directorios a escanear, ahora usa
+los directorios establecidos en el archivo de configuración.
+
 ## Listado de cambios
 
 ### Version 1.0.3 2022-02-22

--- a/src/Internal/SoapXml.php
+++ b/src/Internal/SoapXml.php
@@ -54,7 +54,9 @@ class SoapXml
 
     private function obtainFirstElement(DOMDocument $document, string $elementName): ?DOMElement
     {
-        foreach ($document->getElementsByTagNameNS($this->uri, $elementName) as $consultaResult) {
+        /** @var iterable<DOMElement> $elements */
+        $elements = $document->getElementsByTagNameNS($this->uri, $elementName);
+        foreach ($elements as $consultaResult) {
             return $consultaResult;
         }
         return null;


### PR DESCRIPTION
Se corrige la integración continua porque PHPStan 1.4.8 no reconoce el tipo de elementos contenidos
en un objeto de tipo `DOMNodeList`.

En la integración continua la herramienta `phpcs` tenía fijos los directorios a escanear, ahora usa
los directorios establecidos en el archivo de configuración.