### PR TITLE
Mantenimiento 2023-02-27

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ "main" ]
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           php-version: '8.2'
           coverage: none
-          tools: composer:v2, cs2pr, phpcs
+          tools: cs2pr, phpcs
         env:
           fail-fast: true
       - name: Code style (phpcs)
@@ -40,7 +40,7 @@ jobs:
         with:
           php-version: '8.2'
           coverage: none
-          tools: composer:v2, cs2pr, php-cs-fixer
+          tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Code style (php-cs-fixer)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -92,7 +92,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -123,7 +123,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, cs2pr, phpcs
         env:
@@ -38,13 +38,15 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Code style (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: 1
 
   phpstan:
     name: Code analysis (phpstan)
@@ -55,7 +57,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, phpstan
         env:
@@ -83,7 +85,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, psalm
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -53,7 +53,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -66,7 +66,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -81,7 +81,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -94,7 +94,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -112,7 +112,7 @@ jobs:
         php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -125,7 +125,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,6 @@
 name: coverage
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -59,7 +59,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -87,15 +87,15 @@ jobs:
         id: check-secrets
         run: |
           if [ -n "${{ secrets.GITHUB_TOKEN }}" ]; then
-            echo "::set-output name=github::yes"
+            echo "github=yes" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=github::no"
+            echo "github=no" >> $GITHUB_OUTPUT
             echo "::warning ::GITHUB_TOKEN non set"
           fi
           if [ -n "${{ secrets.SONAR_TOKEN }}" ]; then
-            echo "::set-output name=sonar::yes"
+            echo "sonar=yes" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=sonar::no"
+            echo "sonar=no" >> $GITHUB_OUTPUT
             echo "::warning ::SONAR_TOKEN non set"
           fi
 
@@ -117,7 +117,7 @@ jobs:
           tools: composer:v2
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: xdebug
           tools: composer:v2
         env:
@@ -52,7 +52,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2,infection
         env:
@@ -112,7 +112,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2
       - name: Get composer cache directory

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -27,7 +27,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -37,7 +37,7 @@ jobs:
       - name: Create code coverage
         run: vendor/bin/phpunit --testdox --verbose --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
       - name: Store code coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: code-coverage
           path: build/coverage
@@ -48,7 +48,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -61,7 +61,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -69,7 +69,7 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Obtain code coverage
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: code-coverage
           path: build/coverage
@@ -106,7 +106,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Unshallow clone to provide blame information
         run: git fetch --unshallow
       - name: Setup PHP
@@ -119,7 +119,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -127,7 +127,7 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Obtain code coverage
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: code-coverage
           path: build/coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   tests-coverage:
-    name: Tests on PHP 8.0 (code coverage)
+    name: Create code coverage
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.6.0" installed="3.7.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.4.6" installed="1.4.8" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^4.21.0" installed="4.22.0" location="./tools/psalm" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.14.4" installed="3.14.4" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.10.3" installed="1.10.3" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^4.30.0" installed="4.30.0" location="./tools/psalm" copy="false"/>
   <phar name="infection" version="^0.23.0" installed="0.23.0" location="./tools/infection" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,25 +11,24 @@ declare(strict_types=1);
 
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__ . '/build/php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/php-cs-fixer.cache')
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
-        // PSR12 (remove when php-cs-fixer reaches ^3.1.1)
-        'class_definition' => ['space_before_parenthesis' => true],
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
@@ -37,16 +36,18 @@ return (new PhpCsFixer\Config())
         'standardize_not_equals' => true,
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
+        'fully_qualified_strict_types' => true,
         // symfony:risky
         'no_alias_functions' => true,
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
             ->append([__FILE__])
-            ->exclude(['vendor', 'build'])
+            ->exclude(['vendor', 'tools', 'build']),
     )
 ;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribuciones
 
-Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en el [repositorio GitHub][homepage].
+Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en el [repositorio GitHub][project].
 
 Este proyecto se apega al siguiente [Código de Conducta][coc].
 Al participar en este proyecto y en su comunidad, deberás seguir este código.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2022 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2019 - 2023 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-php-version]: https://img.shields.io/packagist/php-v/phpcfdi/sat-estado-cfdi-http-psr?logo=php
 [badge-release]: https://img.shields.io/github/release/phpcfdi/sat-estado-cfdi-http-psr?logo=git
 [badge-license]: https://img.shields.io/github/license/phpcfdi/sat-estado-cfdi-http-psr?logo=open-source-initiative
-[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/sat-estado-cfdi-http-psr/build/main?logo=github-actions
+[badge-build]: https://img.shields.io/github/actions/workflow/status/phpcfdi/sat-estado-cfdi-http-psr/build.yml?branch=main&logo=github-actions
 [badge-reliability]: https://sonarcloud.io/api/project_badges/measure?project=phpcfdi_sat-estado-cfdi-http-psr&metric=reliability_rating
 [badge-maintainability]: https://sonarcloud.io/api/project_badges/measure?project=phpcfdi_sat-estado-cfdi-http-psr&metric=sqale_rating
 [badge-coverage]: https://img.shields.io/sonar/coverage/phpcfdi_sat-estado-cfdi-http-psr/main?logo=sonarcloud&server=https%3A%2F%2Fsonarcloud.io

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ Los estándares de los que depende son:
 Esta librería no contiene las implementaciones de los estándares, pero ya existen fuera del ámbito de la aplicación.
 
 Te recomiendo probar las librerías de Sunrise
-[`sunrise/http-client-curl`](https://github.com/sunrise-php/http-client-curl),
-[`sunrise/http-factory`](https://github.com/sunrise-php/http-factory) y
+[`sunrise/http-client-curl`](https://github.com/sunrise-php/http-client-curl), y
 [`sunrise/http-message`](https://github.com/sunrise-php/http-message).
 
 O puedes ver en [Packagist](https://packagist.org/) los que te agraden:

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "ext-curl": "*",
         "phpcfdi/cfdi-expresiones": "^3.0",
-        "symfony/http-client": "^5.2",
+        "sunrise/http-client-curl": "^1.4",
         "sunrise/http-message": "^3.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
         "ext-curl": "*",
         "phpcfdi/cfdi-expresiones": "^3.0",
         "symfony/http-client": "^5.2",
-        "sunrise/http-factory": "^1.0",
-        "sunrise/http-message": "^1.0",
+        "sunrise/http-message": "^3.0",
         "phpunit/phpunit": "^9.5"
     },
     "suggest": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,28 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 ## Cambios no liberados en una versión
 
 Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
-versión, aunque sí su incorporación en la rama principal de trabajo. Generalmente se tratan de cambios en el desarrollo.
+versión, aunque sí su incorporación en la rama principal de trabajo. Generalmente, se tratan de cambios en el desarrollo.
+
+### Mantenimiento 2023-02-27
+
+Esta es una actualización de mantenimiento que no genera una nueva liberación de código.
+
+- Se corrige la integración continua porque la librería `sunrise/http-factory` fue deprecada.
+- Se actuailza a `sunrise/http-message:^3.0`.
+- Se actualiza la documentación que hacía referencia a `sunrise/http-factory`.
+- Se sustituye `symfony/http-client` por `sunrise/http-client-curl`.
+- Se actualiza el año en la licencia. ¡Feliz 2023!
+- Se actualiza la configuración de estilo de código a la utilizada por otros proyectos de phpCfdi.
+- Se corrige la insignia `badge-build`.
+- Se corrige la liga al proyecto en la guía de contribución.
+- En los flujos de trabajo de integración continua:
+  - Se agrega PHP 8.2 a la matriz de pruebas
+  - Los trabajos se ejecutan en PHP 8.2
+  - Se actualizan las acciones de GitHub a la versión 3.
+  - Se sustituye la directiva `::set-output` por `$GITHUB_OUTPUT`.
+  - Se elimina la instalación de `composer` donde no es necesaria.
+  - Se agrega el evento `workflow_dispatch`.
+- Se actualizan las herramientas de desarrollo.
 
 ### Fix build 2022-03-08
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,13 +16,14 @@ Esta es una actualización de mantenimiento que no genera una nueva liberación 
 - Se corrige la integración continua porque la librería `sunrise/http-factory` fue deprecada.
 - Se actuailza a `sunrise/http-message:^3.0`.
 - Se actualiza la documentación que hacía referencia a `sunrise/http-factory`.
-- Se sustituye `symfony/http-client` por `sunrise/http-client-curl`.
+- Se sustituye `symfony/http-client` por `sunrise/http-client-curl`. 
 - Se actualiza el año en la licencia. ¡Feliz 2023!
 - Se actualiza la configuración de estilo de código a la utilizada por otros proyectos de phpCfdi.
 - Se corrige la insignia `badge-build`.
 - Se corrige la liga al proyecto en la guía de contribución.
 - En los flujos de trabajo de integración continua:
   - Se agrega PHP 8.2 a la matriz de pruebas
+  - Se quitaPHP 7.3 de la matriz de pruebas porque no hay soporte para *Sunrise PHP*.
   - Los trabajos se ejecutan en PHP 8.2
   - Se actualizan las acciones de GitHub a la versión 3.
   - Se sustituye la directiva `::set-output` por `$GITHUB_OUTPUT`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,12 +15,12 @@ Documentar cómo se puede integrar esta librería con una aplicación de framewo
   - [X] Guzzle (gracias @blacktrue)
   - [ ] HTTPPlug
 
+## Hechas
+
 ### Dependencia de `sunrise/http-client-curl`
 
-Sustituir `symfony/http-client` por `sunrise/http-client-curl` cuando sea compatible con PHP 8.0. 
+Sustituir `symfony/http-client` por `sunrise/http-client-curl` cuando sea compatible con PHP 8.0.
 Así estaba implementado, pero al menos en 2021-01-09 aún no era compatible.
-
-## Hechas
 
 ### Primera versión estable
 

--- a/docs/integracion-generica.md
+++ b/docs/integracion-generica.md
@@ -12,9 +12,9 @@ declare(strict_types=1);
 
 use PhpCfdi\SatEstadoCfdi\HttpPsr\HttpConsumerClient;
 use PhpCfdi\SatEstadoCfdi\HttpPsr\HttpConsumerFactory;
-use Sunrise\Http\Factory\RequestFactory;
-use Sunrise\Http\Factory\ResponseFactory;
-use Sunrise\Http\Factory\StreamFactory;
+use Sunrise\Http\Message\RequestFactory;
+use Sunrise\Http\Message\ResponseFactory;
+use Sunrise\Http\Message\StreamFactory;
 use Sunrise\Http\Client\Curl\Client;
 
 $streamFactory = new StreamFactory();
@@ -40,4 +40,4 @@ en <https://github.com/phpcfdi/sat-estado-cfdi-http-psr/blob/main/tests/TestingH
 ## Implementando HttpConsumerFactoryInterface
 
 Otra forma de hacerlo sería creando una clase que solamente extendiera `HttpConsumerFactoryInterface`.
-Pues el objeto `HttpConsumerClient` requiere en su contructor de un objeto que cumpla con dicha interface.
+Pues el objeto `HttpConsumerClient` requiere en su contructor de un objeto que cumpla con dicha interfaz.

--- a/docs/integracion-generica.md
+++ b/docs/integracion-generica.md
@@ -12,15 +12,15 @@ declare(strict_types=1);
 
 use PhpCfdi\SatEstadoCfdi\HttpPsr\HttpConsumerClient;
 use PhpCfdi\SatEstadoCfdi\HttpPsr\HttpConsumerFactory;
+use Sunrise\Http\Client\Curl\Client as HttpClient;
 use Sunrise\Http\Message\RequestFactory;
 use Sunrise\Http\Message\ResponseFactory;
 use Sunrise\Http\Message\StreamFactory;
-use Sunrise\Http\Client\Curl\Client;
 
 $streamFactory = new StreamFactory();
 $requestFactory = new RequestFactory();
 $responseFactory = new ResponseFactory();
-$client = new Client($responseFactory, $streamFactory);
+$client = new HttpClient($responseFactory);
 
 // use the current HttpConsumerFactory with specific objects
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="EngineWorks">
     <description>The EngineWorks (PSR-2 based) coding standard.</description>
 

--- a/tests/TestingHttpConsumerFactory.php
+++ b/tests/TestingHttpConsumerFactory.php
@@ -9,9 +9,9 @@ use PhpCfdi\SatEstadoCfdi\HttpPsr\HttpConsumerFactoryInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Sunrise\Http\Factory\RequestFactory as SunriseRequestFactory;
-use Sunrise\Http\Factory\ResponseFactory as SunriseResponseFactory;
-use Sunrise\Http\Factory\StreamFactory as SunriseStreamFactory;
+use Sunrise\Http\Message\RequestFactory as SunriseRequestFactory;
+use Sunrise\Http\Message\ResponseFactory as SunriseResponseFactory;
+use Sunrise\Http\Message\StreamFactory as SunriseStreamFactory;
 use Symfony\Component\HttpClient\Psr18Client as SymfonyHttpClient;
 
 final class TestingHttpConsumerFactory extends HttpConsumerFactory implements HttpConsumerFactoryInterface

--- a/tests/TestingHttpConsumerFactory.php
+++ b/tests/TestingHttpConsumerFactory.php
@@ -9,10 +9,10 @@ use PhpCfdi\SatEstadoCfdi\HttpPsr\HttpConsumerFactoryInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Sunrise\Http\Client\Curl\Client as SunriseHttpClient;
 use Sunrise\Http\Message\RequestFactory as SunriseRequestFactory;
 use Sunrise\Http\Message\ResponseFactory as SunriseResponseFactory;
 use Sunrise\Http\Message\StreamFactory as SunriseStreamFactory;
-use Symfony\Component\HttpClient\Psr18Client as SymfonyHttpClient;
 
 final class TestingHttpConsumerFactory extends HttpConsumerFactory implements HttpConsumerFactoryInterface
 {
@@ -23,7 +23,7 @@ final class TestingHttpConsumerFactory extends HttpConsumerFactory implements Ht
     ) {
         $streamFactoryInterface = $streamFactoryInterface ?? new SunriseStreamFactory();
         $requestFactoryInterface = $requestFactoryInterface ?? new SunriseRequestFactory();
-        $httpClient = $httpClient ?? new SymfonyHttpClient(null, new SunriseResponseFactory(), $streamFactoryInterface);
+        $httpClient = $httpClient ?? new SunriseHttpClient(new SunriseResponseFactory());
         parent::__construct($httpClient, $requestFactoryInterface, $streamFactoryInterface);
     }
 }

--- a/tests/Unit/HttpConsumerClientTest.php
+++ b/tests/Unit/HttpConsumerClientTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Client\ClientInterface as HttpClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Sunrise\Http\Factory\ResponseFactory;
+use Sunrise\Http\Message\ResponseFactory;
 
 final class HttpConsumerClientTest extends TestCase
 {


### PR DESCRIPTION
Esta es una actualización de mantenimiento que no genera una nueva liberación de código.

- Se corrige la integración continua porque la librería `sunrise/http-factory` fue deprecada.
- Se actuailza a `sunrise/http-message:^3.0`.
- Se actualiza la documentación que hacía referencia a `sunrise/http-factory`.
- Se sustituye `symfony/http-client` por `sunrise/http-client-curl`.
- Se actualiza el año en la licencia. ¡Feliz 2023!
- Se actualiza la configuración de estilo de código a la utilizada por otros proyectos de phpCfdi.
- Se corrige la insignia `badge-build`.
- Se corrige la liga al proyecto en la guía de contribución.
- En los flujos de trabajo de integración continua:
  - Se agrega PHP 8.2 a la matriz de pruebas
  - Los trabajos se ejecutan en PHP 8.2
  - Se actualizan las acciones de GitHub a la versión 3.
  - Se sustituye la directiva `::set-output` por `$GITHUB_OUTPUT`.
  - Se elimina la instalación de `composer` donde no es necesaria.
  - Se agrega el evento `workflow_dispatch`.
- Se actualizan las herramientas de desarrollo.
